### PR TITLE
Fixed a warning that never triggered correctly

### DIFF
--- a/scripts/jb2a.js
+++ b/scripts/jb2a.js
@@ -58,7 +58,7 @@ Hooks.once('ready', async function () {
         else{
             Sequencer.Database.registerEntries("jb2a", freeDatabase);
         }
-        if(!warning){
+        if(warning){
             ui.notifications.warn(warning);
             return;
         }


### PR DESCRIPTION
I found a small mistake in this script.
This mistake resulted in an **empty warning notification** triggering every time on page load when nothing was actually wrong and **no warning** triggering **when both patreon and free version were enabled** (which was the actual intent of the code snippet).
