### PR TITLE
Create an automated release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,9 @@ jobs:
         run: echo "module_id=${{fromJson(steps.set_var.outputs.PACKAGE_JSON).id}}" >> "$GITHUB_OUTPUT"
 
       # Publish to FoundryVTT
-      - name: Publish to Foundry VTT Repo
-        id: publish_foundry_repo
-        if: '!github.event.release.prerelease && env.FVTT_USERNAME'
-        run: npx @ghost-fvtt/foundry-publish
-        env:
-          FVTT_MANIFEST_PATH: module.json
-          FVTT_PACKAGE_ID: ${{steps.module_id.outputs.module_id}}
-          FVTT_USE_NEW_PACKAGE_ADMINISTRATION_INTERFACE: true
-          FVTT_USERNAME: ${{ secrets.FOUNDRY_ADMIN_USERNAME }}
-          FVTT_PASSWORD: ${{ secrets.FOUNDRY_ADMIN_PASSWORD }}
-          FVTT_MANIFEST_URL: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+      - name: Publish FoundryVTT Package
+        if: '!github.event.release.prerelease && env.package-token'
+        uses: cs96and/FoundryVTT-release-package@v1.0.2
+        with:
+          package-token: ${{ secrets.PACKAGE_TOKEN }}
+          manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,69 @@
+name: Release Creation
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      # get part of the tag after the `v`
+      - name: Extract tag version number
+        id: get-version
+        run: echo "version-without-v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # Substitute the Manifest and Download URLs in the `module.json`.
+      - name: Substitute Manifest and Download Links For Versioned Ones
+        id: sub_manifest_link_version
+        uses: devops-actions/variable-substitution@v1.2
+        with:
+          files: module.json
+        env:
+          version: ${{steps.get-version.outputs.version-without-v}}
+          manifest: https://raw.githubusercontent.com/${{github.repository}}/latest/download/module.json
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
+      # Create a folder containing all the module stuff and zip it for the release
+      - name: Create Zip
+        run: zip -r9 ./module.zip module.json artwork/ dev/ Library/ packs/ scripts/ License.txt README.md
+
+      - name: Update Release with Files
+        id: create_version_release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          artifacts: './module.json, ./module.zip'
+
+      # https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
+      - id: set_var
+        run: |
+          echo "PACKAGE_JSON=$(jq -c . < module.json)" >> $GITHUB_OUTPUT
+
+      - name: Get Module ID
+        id: module_id
+        run: echo "module_id=${{fromJson(steps.set_var.outputs.PACKAGE_JSON).id}}" >> "$GITHUB_OUTPUT"
+
+      # Publish to FoundryVTT
+      - name: Publish to Foundry VTT Repo
+        id: publish_foundry_repo
+        if: '!github.event.release.prerelease && env.FVTT_USERNAME'
+        run: npx @ghost-fvtt/foundry-publish
+        env:
+          FVTT_MANIFEST_PATH: module.json
+          FVTT_PACKAGE_ID: ${{steps.module_id.outputs.module_id}}
+          FVTT_USE_NEW_PACKAGE_ADMINISTRATION_INTERFACE: true
+          FVTT_USERNAME: ${{ secrets.FOUNDRY_ADMIN_USERNAME }}
+          FVTT_PASSWORD: ${{ secrets.FOUNDRY_ADMIN_PASSWORD }}
+          FVTT_MANIFEST_URL: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json

--- a/module.json
+++ b/module.json
@@ -1,19 +1,18 @@
 {
   "name": "JB2A_DnD5e",
-  "id": "JB2A_DnD5e",  
+  "id": "JB2A_DnD5e",
   "title": "JB2A - Jules and Ben's Animated Assets - Free Content",
   "description": "<p>Animated Assets for spells, tiles, tokens, melee and ranged attacks</p><p>Troubleshooting and FAQ section on our <a href='https://jb2a.com'>website</a> </p><p>Join our <a href='https://discord.gg/gmd8MAPX4m'>Discord server</a> for any further questions</p><p> <a href='https://www.jb2a.com/Library_Preview/'>Preview</a> our assets<br><p>Consider supporting us on <a href='https://www.patreon.com/JB2A'>Patreon</a> for more ! </p>",
-  "author": "Gazkhan#8192 and Wassily#8035", 
   "authors": [
     {
       "name": "Jules",
       "url": "https://www.patreon.com/JB2A",
-      "discord": "Gazkhan#8192"
+      "discord": "gazkhan"
     },
     {
       "name": "Ben",
       "url": "https://www.patreon.com/JB2A",
-      "discord": "Wassily#8035"
+      "discord": "wassily"
     }
   ],
   "url": "https://www.patreon.com/JB2A",
@@ -43,12 +42,11 @@
   ],
   "media": [
     {
-    "type": "setup",
-    "url": "https://www.jb2a.com/artwork/Gifs/animated-banner.gif",
-    "thumbnail": ""
+      "type": "setup",
+      "url": "https://www.jb2a.com/artwork/Gifs/animated-banner.gif",
+      "thumbnail": ""
     }
   ],
-  "type": "module",
   "esmodules": [
     "./scripts/jb2a.js"
   ],


### PR DESCRIPTION
This PR does two things:
- Removes unneeded properties in the `module.json` to prevent Foundry annoying people about them.
- Creates an automated GitHub Action that zips up the module and makes a release with it. 
  - It also includes automatic creation of a new version on the FoundryVTT website, which requires storing a [SECRET](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) of the release API key, which you get from here 
![chrome_O40XQnyAqB](https://github.com/Jules-Bens-Aa/JB2A_DnD5e/assets/32039708/4b6b5473-3a62-4214-902d-198336ee47a8)
